### PR TITLE
feat: create Tags components

### DIFF
--- a/src/__test__/__snapshots__/storyshop.test.ts.snap
+++ b/src/__test__/__snapshots__/storyshop.test.ts.snap
@@ -84,7 +84,7 @@ exports[`Storyshots atoms/Tag Default 1`] = `
 
 exports[`Storyshots molecules/Tags Default 1`] = `
 <ul
-  className="Tags__TagsWrapper-sc-16wimeq-0 iEosHM"
+  className="Tags__TagsWrapper-sc-16wimeq-0 gyEMZL"
 >
   <li
     className="Tag__TagWrapper-sc-14oc89a-0 dapIqC"

--- a/src/__test__/__snapshots__/storyshop.test.ts.snap
+++ b/src/__test__/__snapshots__/storyshop.test.ts.snap
@@ -75,7 +75,7 @@ exports[`Storyshots atoms/Logo Logo 1`] = `
 
 exports[`Storyshots atoms/Tag Default 1`] = `
 <li
-  className="Tag__TagWrapper-sc-14oc89a-0 dapIqC"
+  className="Tag__TagWrapper-sc-14oc89a-0 fFAOxz"
   color="#ff0000"
 >
   Tag
@@ -87,19 +87,19 @@ exports[`Storyshots molecules/Tags Default 1`] = `
   className="Tags__TagsWrapper-sc-16wimeq-0 gyEMZL"
 >
   <li
-    className="Tag__TagWrapper-sc-14oc89a-0 dapIqC"
+    className="Tag__TagWrapper-sc-14oc89a-0 fFAOxz"
     color="#ff0000"
   >
     Tag-A
   </li>
   <li
-    className="Tag__TagWrapper-sc-14oc89a-0 gGhdpi"
+    className="Tag__TagWrapper-sc-14oc89a-0 gMeWhr"
     color="green"
   >
     Tag-B
   </li>
   <li
-    className="Tag__TagWrapper-sc-14oc89a-0 cAqBke"
+    className="Tag__TagWrapper-sc-14oc89a-0 jeIcJj"
     color="#0000ff"
   >
     Tag-C

--- a/src/__test__/__snapshots__/storyshop.test.ts.snap
+++ b/src/__test__/__snapshots__/storyshop.test.ts.snap
@@ -82,6 +82,31 @@ exports[`Storyshots atoms/Tag Default 1`] = `
 </li>
 `;
 
+exports[`Storyshots molecules/Tags Default 1`] = `
+<ul
+  className="Tags__TagsWrapper-sc-16wimeq-0 iEosHM"
+>
+  <li
+    className="Tag__TagWrapper-sc-14oc89a-0 dapIqC"
+    color="#ff0000"
+  >
+    Tag-A
+  </li>
+  <li
+    className="Tag__TagWrapper-sc-14oc89a-0 gGhdpi"
+    color="green"
+  >
+    Tag-B
+  </li>
+  <li
+    className="Tag__TagWrapper-sc-14oc89a-0 cAqBke"
+    color="#0000ff"
+  >
+    Tag-C
+  </li>
+</ul>
+`;
+
 exports[`Storyshots organisms/Footer Footer 1`] = `
 <footer
   className="Footer__Wrapper-sc-10gingb-0 jJIwnP"

--- a/src/components/atoms/Tag/index.stories.tsx
+++ b/src/components/atoms/Tag/index.stories.tsx
@@ -9,6 +9,6 @@ export default {
 export const Default: ComponentStoryObj<typeof Tag> = {
   args: {
     color: '#ff0000',
-    children: 'Tag',
+    name: 'Tag',
   },
 };

--- a/src/components/atoms/Tag/index.tsx
+++ b/src/components/atoms/Tag/index.tsx
@@ -1,3 +1,4 @@
+import { ResponsiveFontSize } from 'src/styles/responsives';
 import { spacingSizes } from 'src/styles/Tokens';
 import styled from 'styled-components';
 
@@ -12,6 +13,8 @@ const TagWrapper = styled.li<Pick<TagProps, 'color'>>`
   color: white;
   list-style: none;
   padding: 0 ${spacingSizes.xs};
+
+  ${ResponsiveFontSize}
 `;
 
 export const Tag = ({ name, color }: TagProps): JSX.Element => (

--- a/src/components/atoms/Tag/index.tsx
+++ b/src/components/atoms/Tag/index.tsx
@@ -2,7 +2,7 @@ import { spacingSizes } from 'src/styles/Tokens';
 import styled from 'styled-components';
 
 export type TagProps = {
-  children: string;
+  name: string;
   color: string;
 };
 
@@ -14,6 +14,6 @@ const TagWrapper = styled.li<Pick<TagProps, 'color'>>`
   padding: 0 ${spacingSizes.xs};
 `;
 
-export const Tag = ({ children, color }: TagProps): JSX.Element => (
-  <TagWrapper color={color}>{children}</TagWrapper>
+export const Tag = ({ name, color }: TagProps): JSX.Element => (
+  <TagWrapper color={color}>{name}</TagWrapper>
 );

--- a/src/components/molecules/Tags/index.stories.tsx
+++ b/src/components/molecules/Tags/index.stories.tsx
@@ -1,0 +1,17 @@
+import { ComponentMeta, ComponentStoryObj } from '@storybook/react';
+import { Tags } from '.';
+
+export default {
+  component: Tags,
+  title: 'molecules/Tags',
+} as ComponentMeta<typeof Tags>;
+
+export const Default: ComponentStoryObj<typeof Tags> = {
+  args: {
+    tags: [
+      { name: 'Tag-A', color: '#ff0000' },
+      { name: 'Tag-B', color: 'green' },
+      { name: 'Tag-C', color: '#0000ff' },
+    ],
+  },
+};

--- a/src/components/molecules/Tags/index.tsx
+++ b/src/components/molecules/Tags/index.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 
 const TagsWrapper = styled.ul`
   display: flex;
+  flex-wrap: wrap;
   gap: ${spacingSizes.xxs};
 `;
 

--- a/src/components/molecules/Tags/index.tsx
+++ b/src/components/molecules/Tags/index.tsx
@@ -1,13 +1,20 @@
 import { Tag, TagProps } from 'src/components/atoms/Tag';
+import { spacingSizes } from 'src/styles/Tokens';
+import styled from 'styled-components';
+
+const TagsWrapper = styled.ul`
+  display: flex;
+  gap: ${spacingSizes.xxs};
+`;
 
 export type TagsProps = {
   tags: TagProps[];
 };
 
 export const Tags = ({ tags }: TagsProps): JSX.Element => (
-  <ul>
+  <TagsWrapper>
     {tags.map((tag) => (
       <Tag key={tag.name} {...tag} />
     ))}
-  </ul>
+  </TagsWrapper>
 );

--- a/src/components/molecules/Tags/index.tsx
+++ b/src/components/molecules/Tags/index.tsx
@@ -1,0 +1,13 @@
+import { Tag, TagProps } from 'src/components/atoms/Tag';
+
+export type TagsProps = {
+  tags: TagProps[];
+};
+
+export const Tags = ({ tags }: TagsProps): JSX.Element => (
+  <ul>
+    {tags.map((tag) => (
+      <Tag key={tag.name} {...tag} />
+    ))}
+  </ul>
+);

--- a/src/styles/breakpoint.ts
+++ b/src/styles/breakpoint.ts
@@ -11,12 +11,12 @@ export const breakpoint: Record<Breakpoints, BreakpointFn> = {
     ${mb}
   `,
   tb: (tb) => css`
-    @media (min-width: 640px) {
+    @media (min-width: 768px) {
       ${tb}
     }
   `,
   pc: (pc) => css`
-    @media (min-width: 768px) {
+    @media (min-width: 1152px) {
       ${pc}
     }
   `,

--- a/src/styles/breakpoint.ts
+++ b/src/styles/breakpoint.ts
@@ -1,0 +1,23 @@
+import { FlattenSimpleInterpolation, css } from 'styled-components';
+
+type Breakpoints = 'mb' | 'tb' | 'pc';
+
+type BreakpointFn = (
+  style: FlattenSimpleInterpolation,
+) => FlattenSimpleInterpolation;
+
+export const breakpoint: Record<Breakpoints, BreakpointFn> = {
+  mb: (mb) => css`
+    ${mb}
+  `,
+  tb: (tb) => css`
+    @media (min-width: 640px) {
+      ${tb}
+    }
+  `,
+  pc: (pc) => css`
+    @media (min-width: 768px) {
+      ${pc}
+    }
+  `,
+};

--- a/src/styles/responsives.ts
+++ b/src/styles/responsives.ts
@@ -1,0 +1,17 @@
+import { css } from 'styled-components';
+import { breakpoint } from './breakpoint';
+
+export const ResponsiveFontSize = css`
+  ${() =>
+    breakpoint.mb(css`
+      font-size: 12px;
+    `)}
+  ${() =>
+    breakpoint.tb(css`
+      font-size: 12px;
+    `)}
+  ${() =>
+    breakpoint.pc(css`
+      font-size: 22px;
+    `)}
+`;


### PR DESCRIPTION
# 概要
Tags コンポーネントを作成しました。

# 実装方針
- Props に `TagProps` の配列を渡すようにして、Tag のリストを生成できるようにしました。
- `Tag` コンポーネントの props で、`children` が　`string` であると混乱が生じる恐れがあるので、`children` を `name` に置き換えました。

# 動作手順

- Storybook のリンク: http://localhost:6006/?path=/story/molecules-tags--default

# キャプチャ
<img width="947" alt="image" src="https://user-images.githubusercontent.com/55672846/187138740-60079d38-e1f8-4b15-9958-b6f7ab89d3bb.png">

# レビュー観点 (あれば)
