### PR TITLE
feat: implement WideCard component

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@typescript-eslint/eslint-plugin": "^5.12.1",
     "@typescript-eslint/parser": "^5.9.0",
     "babel-jest": "^27.4.6",
+    "dayjs": "^1.11.5",
     "eslint": "^8.6.0",
     "eslint-config-airbnb": "^19.0.4",
     "eslint-config-prettier": "^8.3.0",

--- a/src/__test__/__snapshots__/storyshop.test.ts.snap
+++ b/src/__test__/__snapshots__/storyshop.test.ts.snap
@@ -179,7 +179,7 @@ exports[`Storyshots atoms/Tag Default 1`] = `
 
 exports[`Storyshots molecules/Tags Default 1`] = `
 <ul
-  className="Tags__TagsWrapper-sc-16wimeq-0 gyEMZL"
+  className="Tags__TagsWrapper-sc-16wimeq-0 gBggRX"
 >
   <li
     className="Tag__TagWrapper-sc-14oc89a-0 hkYttr"
@@ -200,6 +200,49 @@ exports[`Storyshots molecules/Tags Default 1`] = `
     Tag-C
   </li>
 </ul>
+`;
+
+exports[`Storyshots molecules/WideCard Default 1`] = `
+<article
+  className="WideCard__WideCardWrapper-sc-nrwjyl-0 iVTiwl"
+>
+  <div
+    className="WideCard__MetaInformationLine-sc-nrwjyl-1 dYkBPa"
+  >
+    <time
+      className="WideCard__Date-sc-nrwjyl-2 eGsMRn"
+    >
+      2022/08/30
+    </time>
+    <ul
+      className="Tags__TagsWrapper-sc-16wimeq-0 gBggRX"
+    >
+      <li
+        className="Tag__TagWrapper-sc-14oc89a-0 eXcEJX"
+        color="red"
+      >
+        Tag-1
+      </li>
+      <li
+        className="Tag__TagWrapper-sc-14oc89a-0 fgdIoT"
+        color="green"
+      >
+        Tag-2
+      </li>
+      <li
+        className="Tag__TagWrapper-sc-14oc89a-0 bYpkuq"
+        color="blue"
+      >
+        Tag-3
+      </li>
+    </ul>
+  </div>
+  <p
+    className="WideCard__Content-sc-nrwjyl-3 kAkQkf"
+  >
+    WideCard component WideCard component WideCard component WideCard component WideCard component WideCard component WideCard component WideCard component WideCard component WideCard component 
+  </p>
+</article>
 `;
 
 exports[`Storyshots organisms/Footer Footer 1`] = `

--- a/src/__test__/__snapshots__/storyshop.test.ts.snap
+++ b/src/__test__/__snapshots__/storyshop.test.ts.snap
@@ -179,7 +179,7 @@ exports[`Storyshots atoms/Tag Default 1`] = `
 
 exports[`Storyshots molecules/Tags Default 1`] = `
 <ul
-  className="Tags__TagsWrapper-sc-16wimeq-0 gBggRX"
+  className="Tags__TagsWrapper-sc-16wimeq-0 dwINUO"
 >
   <li
     className="Tag__TagWrapper-sc-14oc89a-0 hkYttr"
@@ -207,15 +207,16 @@ exports[`Storyshots molecules/WideCard Default 1`] = `
   className="WideCard__WideCardWrapper-sc-nrwjyl-0 iVTiwl"
 >
   <div
-    className="WideCard__MetaInformationLine-sc-nrwjyl-1 dYkBPa"
+    className="WideCard__MetaInformationLine-sc-nrwjyl-1 cuvZVz"
   >
     <time
-      className="WideCard__Date-sc-nrwjyl-2 eGsMRn"
+      className="WideCard__Date-sc-nrwjyl-2 bfpOWL"
+      dateTime="2022-08-30"
     >
       2022/08/30
     </time>
     <ul
-      className="Tags__TagsWrapper-sc-16wimeq-0 gBggRX"
+      className="Tags__TagsWrapper-sc-16wimeq-0 dwINUO"
     >
       <li
         className="Tag__TagWrapper-sc-14oc89a-0 eXcEJX"

--- a/src/components/molecules/Tags/index.tsx
+++ b/src/components/molecules/Tags/index.tsx
@@ -1,12 +1,19 @@
 import { Tag, TagProps } from 'src/components/atoms/Tag';
+import { breakpoint } from 'src/styles/breakpoint';
 import { spacingSizes } from 'src/styles/Tokens';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 const TagsWrapper = styled.ul`
   display: flex;
   flex-wrap: wrap;
-  gap: ${spacingSizes.xxs};
   align-items: center;
+
+  ${breakpoint.mb(css`
+    gap: ${spacingSizes.xxs};
+  `)}
+  ${breakpoint.pc(css`
+    gap: ${spacingSizes.sm};
+  `)}
 `;
 
 export type TagsProps = {

--- a/src/components/molecules/Tags/index.tsx
+++ b/src/components/molecules/Tags/index.tsx
@@ -6,6 +6,7 @@ const TagsWrapper = styled.ul`
   display: flex;
   flex-wrap: wrap;
   gap: ${spacingSizes.xxs};
+  align-items: center;
 `;
 
 export type TagsProps = {

--- a/src/components/molecules/WideCard/index.stories.tsx
+++ b/src/components/molecules/WideCard/index.stories.tsx
@@ -14,6 +14,6 @@ export const Default: ComponentStoryObj<typeof WideCard> = {
       { color: 'green', name: 'Tag-2' },
       { color: 'blue', name: 'Tag-3' },
     ],
-    text: 'WideCard component '.repeat(50),
+    text: 'WideCard component '.repeat(10),
   },
 };

--- a/src/components/molecules/WideCard/index.stories.tsx
+++ b/src/components/molecules/WideCard/index.stories.tsx
@@ -1,0 +1,19 @@
+import { ComponentMeta, ComponentStoryObj } from '@storybook/react';
+import { WideCard } from '.';
+
+export default {
+  component: WideCard,
+  title: 'molecules/WideCard',
+} as ComponentMeta<typeof WideCard>;
+
+export const Default: ComponentStoryObj<typeof WideCard> = {
+  args: {
+    date: '2022/08/30',
+    tags: [
+      { color: 'red', name: 'Tag-1' },
+      { color: 'green', name: 'Tag-2' },
+      { color: 'blue', name: 'Tag-3' },
+    ],
+    text: 'WideCard component '.repeat(50),
+  },
+};

--- a/src/components/molecules/WideCard/index.tsx
+++ b/src/components/molecules/WideCard/index.tsx
@@ -1,0 +1,16 @@
+import { TagProps } from 'src/components/atoms/Tag';
+import { Tags } from '../Tags';
+
+export type WideCardProps = {
+  date: string;
+  tags: TagProps[];
+  text: string;
+};
+export const WideCard = ({ date, tags, text }: WideCardProps): JSX.Element => (
+  <div>
+    {/* TODO: add `datetime` props */}
+    <time>{date}</time>
+    <Tags tags={tags} />
+    <p>{text}</p>
+  </div>
+);

--- a/src/components/molecules/WideCard/index.tsx
+++ b/src/components/molecules/WideCard/index.tsx
@@ -26,10 +26,18 @@ const WideCardWrapper = styled.article`
 
 const MetaInformationLine = styled.div`
   display: flex;
-  gap: ${spacingSizes.xs};
+  align-items: center;
+
+  ${breakpoint.mb(css`
+    gap: ${spacingSizes.xs};
+  `)}
+  ${breakpoint.pc(css`
+    gap: ${spacingSizes.sm};
+  `)}
 `;
 
 const Date = styled.time`
+  line-height: 1;
   font-weight: 700;
 
   ${breakpoint.mb(css`

--- a/src/components/molecules/WideCard/index.tsx
+++ b/src/components/molecules/WideCard/index.tsx
@@ -3,6 +3,7 @@ import { breakpoint } from 'src/styles/breakpoint';
 import { fontSizes, roundings, shadows, spacingSizes } from 'src/styles/Tokens';
 import styled, { css } from 'styled-components';
 import { Tags } from 'src/components/molecules/Tags';
+import dayjs from 'dayjs';
 
 const WideCardWrapper = styled.article`
   display: flex;
@@ -53,13 +54,22 @@ export type WideCardProps = {
   tags: TagProps[];
   text: string;
 };
-export const WideCard = ({ date, tags, text }: WideCardProps): JSX.Element => (
-  <WideCardWrapper>
-    <MetaInformationLine>
-      {/* TODO: add `datetime` props */}
-      <Date>{date}</Date>
-      <Tags tags={tags} />
-    </MetaInformationLine>
-    <Content>{text}</Content>
-  </WideCardWrapper>
-);
+export const WideCard = ({
+  date: rawDate,
+  tags,
+  text,
+}: WideCardProps): JSX.Element => {
+  const date = dayjs(rawDate);
+
+  return (
+    <WideCardWrapper>
+      <MetaInformationLine>
+        <Date dateTime={date.format('YYYY-MM-DD')}>
+          {date.format('YYYY/MM/DD')}
+        </Date>
+        <Tags tags={tags} />
+      </MetaInformationLine>
+      <Content>{text}</Content>
+    </WideCardWrapper>
+  );
+};

--- a/src/components/molecules/WideCard/index.tsx
+++ b/src/components/molecules/WideCard/index.tsx
@@ -1,5 +1,52 @@
 import { TagProps } from 'src/components/atoms/Tag';
+import { breakpoint } from 'src/styles/breakpoint';
+import { fontSizes, roundings, shadows, spacingSizes } from 'src/styles/Tokens';
+import styled, { css } from 'styled-components';
 import { Tags } from '../Tags';
+
+const WideCardWrapper = styled.article`
+  display: flex;
+  flex-direction: column;
+  gap: ${spacingSizes.xs};
+
+  box-shadow: ${shadows.md};
+  border-radius: ${roundings.sm};
+
+  ${breakpoint.mb(css`
+    padding: ${spacingSizes.xs};
+  `)}
+  ${breakpoint.tb(css`
+    padding: ${spacingSizes.xs} ${spacingSizes.sm};
+  `)}
+  ${breakpoint.pc(css`
+    padding: ${spacingSizes.sm};
+  `)}
+`;
+
+const MetaInformationLine = styled.div`
+  display: flex;
+  gap: ${spacingSizes.xs};
+`;
+
+const Date = styled.time`
+  font-weight: 700;
+
+  ${breakpoint.mb(css`
+    font-size: ${fontSizes.fontSize14};
+  `)}
+  ${breakpoint.pc(css`
+    font-size: ${fontSizes.fontSize24};
+  `)}
+`;
+
+const Content = styled.p`
+  ${breakpoint.mb(css`
+    font-size: ${fontSizes.fontSize12};
+  `)}
+  ${breakpoint.pc(css`
+    font-size: ${fontSizes.fontSize18};
+  `)}
+`;
 
 export type WideCardProps = {
   date: string;
@@ -7,10 +54,12 @@ export type WideCardProps = {
   text: string;
 };
 export const WideCard = ({ date, tags, text }: WideCardProps): JSX.Element => (
-  <div>
-    {/* TODO: add `datetime` props */}
-    <time>{date}</time>
-    <Tags tags={tags} />
-    <p>{text}</p>
-  </div>
+  <WideCardWrapper>
+    <MetaInformationLine>
+      {/* TODO: add `datetime` props */}
+      <Date>{date}</Date>
+      <Tags tags={tags} />
+    </MetaInformationLine>
+    <Content>{text}</Content>
+  </WideCardWrapper>
 );

--- a/src/components/molecules/WideCard/index.tsx
+++ b/src/components/molecules/WideCard/index.tsx
@@ -2,7 +2,7 @@ import { TagProps } from 'src/components/atoms/Tag';
 import { breakpoint } from 'src/styles/breakpoint';
 import { fontSizes, roundings, shadows, spacingSizes } from 'src/styles/Tokens';
 import styled, { css } from 'styled-components';
-import { Tags } from '../Tags';
+import { Tags } from 'src/components/molecules/Tags';
 
 const WideCardWrapper = styled.article`
   display: flex;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6175,6 +6175,11 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
+dayjs@^1.11.5:
+  version "1.11.5"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.5.tgz#00e8cc627f231f9499c19b38af49f56dc0ac5e93"
+  integrity sha512-CAdX5Q3YW3Gclyo5Vpqkgpj8fSdLQcRuzfX6mC6Phy0nfJ0eGYOeS7m4mt2plDWLAtA4TqTakvbboHvUxfe4iA==
+
 debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"


### PR DESCRIPTION
# 概要
WideCard　コンポーネントを実装しました。

# 実装方針
- `date` props は、アプリケーション内の他の部分で `Date` などの別の型に変更することがないことから、普通の `string` として定義しました。

# 動作手順

- Storybook のリンク: http://localhost:6006/?path=/story/molecules-widecard--default&globals=backgrounds.grid:false

# キャプチャ
<img width="1148" alt="image" src="https://user-images.githubusercontent.com/55672846/187334062-de8a30c7-7a0b-4ef0-a32e-52ce71379d48.png">

# レビュー観点 (あれば)
