### PR TITLE
ci: construct test CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,21 @@
+name: Run test
+
+on:
+  push:
+    branches: ['master']
+  pull_request:
+    branches: ['master']
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: v16.13.1
+          cache: 'yarn'
+      - run: yarn install --frozen-lockfile
+      - run: yarn test


### PR DESCRIPTION
# 概要
スナップショットテストを更新するのを失念することが多かったため、　CI を用いて自動で更新し忘れをチェックするようにしました。

# 実装方針
- キャッシュは `actions/setup-node` が提供しているものをそのまま利用しています。

# 動作手順
特になし

# キャプチャ

# レビュー観点 (あれば)
