### PR TITLE
feat: prepare for API, add campaign list connected to API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_API_ORIGIN=(origin of server, without suffix '/')

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "react-slick": "^0.29.0",
-    "slick-carousel": "^1.8.1"
+    "slick-carousel": "^1.8.1",
+    "swr": "^1.3.0"
   },
   "devDependencies": {
     "@next/eslint-plugin-next": "^12.1.0",

--- a/src/__test__/__snapshots__/storyshop.test.ts.snap
+++ b/src/__test__/__snapshots__/storyshop.test.ts.snap
@@ -1184,6 +1184,7 @@ exports[`Storyshots atoms/SimpleCard Default 1`] = `
       }
     >
       <img
+        className="SimpleCard__RoundedNextImage-sc-1rn6x81-3 fQfLSb"
         data-nimg="fill"
         decoding="async"
         src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
@@ -1212,6 +1213,7 @@ exports[`Storyshots atoms/SimpleCard Default 1`] = `
       />
       <noscript>
         <img
+          className="SimpleCard__RoundedNextImage-sc-1rn6x81-3 fQfLSb"
           data-nimg="fill"
           decoding="async"
           loading="lazy"
@@ -1330,7 +1332,7 @@ exports[`Storyshots molecules/WideCard Default 1`] = `
 
 exports[`Storyshots organisms/CampaignList Default 1`] = `
 <div
-  className="CampaignList__CardList-sc-18q27e9-0 fkfzHV"
+  className="CampaignList__CardList-sc-18q27e9-0 bwDwmL"
 >
   <article
     className="SimpleCard__CardWrapper-sc-1rn6x81-0 jPxKjc"
@@ -1360,6 +1362,7 @@ exports[`Storyshots organisms/CampaignList Default 1`] = `
         }
       >
         <img
+          className="SimpleCard__RoundedNextImage-sc-1rn6x81-3 fQfLSb"
           data-nimg="fill"
           decoding="async"
           src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
@@ -1388,6 +1391,7 @@ exports[`Storyshots organisms/CampaignList Default 1`] = `
         />
         <noscript>
           <img
+            className="SimpleCard__RoundedNextImage-sc-1rn6x81-3 fQfLSb"
             data-nimg="fill"
             decoding="async"
             loading="lazy"
@@ -1452,6 +1456,7 @@ exports[`Storyshots organisms/CampaignList Default 1`] = `
         }
       >
         <img
+          className="SimpleCard__RoundedNextImage-sc-1rn6x81-3 fQfLSb"
           data-nimg="fill"
           decoding="async"
           src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
@@ -1480,6 +1485,7 @@ exports[`Storyshots organisms/CampaignList Default 1`] = `
         />
         <noscript>
           <img
+            className="SimpleCard__RoundedNextImage-sc-1rn6x81-3 fQfLSb"
             data-nimg="fill"
             decoding="async"
             loading="lazy"
@@ -1544,6 +1550,7 @@ exports[`Storyshots organisms/CampaignList Default 1`] = `
         }
       >
         <img
+          className="SimpleCard__RoundedNextImage-sc-1rn6x81-3 fQfLSb"
           data-nimg="fill"
           decoding="async"
           src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
@@ -1572,6 +1579,7 @@ exports[`Storyshots organisms/CampaignList Default 1`] = `
         />
         <noscript>
           <img
+            className="SimpleCard__RoundedNextImage-sc-1rn6x81-3 fQfLSb"
             data-nimg="fill"
             decoding="async"
             loading="lazy"
@@ -1636,6 +1644,7 @@ exports[`Storyshots organisms/CampaignList Default 1`] = `
         }
       >
         <img
+          className="SimpleCard__RoundedNextImage-sc-1rn6x81-3 fQfLSb"
           data-nimg="fill"
           decoding="async"
           src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
@@ -1664,6 +1673,7 @@ exports[`Storyshots organisms/CampaignList Default 1`] = `
         />
         <noscript>
           <img
+            className="SimpleCard__RoundedNextImage-sc-1rn6x81-3 fQfLSb"
             data-nimg="fill"
             decoding="async"
             loading="lazy"
@@ -1728,6 +1738,7 @@ exports[`Storyshots organisms/CampaignList Default 1`] = `
         }
       >
         <img
+          className="SimpleCard__RoundedNextImage-sc-1rn6x81-3 fQfLSb"
           data-nimg="fill"
           decoding="async"
           src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
@@ -1756,6 +1767,7 @@ exports[`Storyshots organisms/CampaignList Default 1`] = `
         />
         <noscript>
           <img
+            className="SimpleCard__RoundedNextImage-sc-1rn6x81-3 fQfLSb"
             data-nimg="fill"
             decoding="async"
             loading="lazy"
@@ -1820,6 +1832,7 @@ exports[`Storyshots organisms/CampaignList Default 1`] = `
         }
       >
         <img
+          className="SimpleCard__RoundedNextImage-sc-1rn6x81-3 fQfLSb"
           data-nimg="fill"
           decoding="async"
           src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
@@ -1848,6 +1861,7 @@ exports[`Storyshots organisms/CampaignList Default 1`] = `
         />
         <noscript>
           <img
+            className="SimpleCard__RoundedNextImage-sc-1rn6x81-3 fQfLSb"
             data-nimg="fill"
             decoding="async"
             loading="lazy"

--- a/src/__test__/__snapshots__/storyshop.test.ts.snap
+++ b/src/__test__/__snapshots__/storyshop.test.ts.snap
@@ -1157,7 +1157,7 @@ exports[`Storyshots atoms/Logo Logo 1`] = `
 
 exports[`Storyshots atoms/SimpleCard Default 1`] = `
 <article
-  className="SimpleCard__CardWrapper-sc-1rn6x81-0 jPxKjc"
+  className="SimpleCard__CardWrapper-sc-1rn6x81-0 eXcGaU"
 >
   <section
     className="SimpleCard__Image-sc-1rn6x81-1 ixHnGb"
@@ -1332,10 +1332,10 @@ exports[`Storyshots molecules/WideCard Default 1`] = `
 
 exports[`Storyshots organisms/CampaignList Default 1`] = `
 <div
-  className="CampaignList__CardList-sc-18q27e9-0 bwDwmL"
+  className="CampaignList__CardList-sc-18q27e9-0 hAwqHH"
 >
   <article
-    className="SimpleCard__CardWrapper-sc-1rn6x81-0 jPxKjc"
+    className="SimpleCard__CardWrapper-sc-1rn6x81-0 eXcGaU"
   >
     <section
       className="SimpleCard__Image-sc-1rn6x81-1 ixHnGb"
@@ -1429,7 +1429,7 @@ exports[`Storyshots organisms/CampaignList Default 1`] = `
     </section>
   </article>
   <article
-    className="SimpleCard__CardWrapper-sc-1rn6x81-0 jPxKjc"
+    className="SimpleCard__CardWrapper-sc-1rn6x81-0 eXcGaU"
   >
     <section
       className="SimpleCard__Image-sc-1rn6x81-1 ixHnGb"
@@ -1523,7 +1523,7 @@ exports[`Storyshots organisms/CampaignList Default 1`] = `
     </section>
   </article>
   <article
-    className="SimpleCard__CardWrapper-sc-1rn6x81-0 jPxKjc"
+    className="SimpleCard__CardWrapper-sc-1rn6x81-0 eXcGaU"
   >
     <section
       className="SimpleCard__Image-sc-1rn6x81-1 ixHnGb"
@@ -1617,7 +1617,7 @@ exports[`Storyshots organisms/CampaignList Default 1`] = `
     </section>
   </article>
   <article
-    className="SimpleCard__CardWrapper-sc-1rn6x81-0 jPxKjc"
+    className="SimpleCard__CardWrapper-sc-1rn6x81-0 eXcGaU"
   >
     <section
       className="SimpleCard__Image-sc-1rn6x81-1 ixHnGb"
@@ -1711,7 +1711,7 @@ exports[`Storyshots organisms/CampaignList Default 1`] = `
     </section>
   </article>
   <article
-    className="SimpleCard__CardWrapper-sc-1rn6x81-0 jPxKjc"
+    className="SimpleCard__CardWrapper-sc-1rn6x81-0 eXcGaU"
   >
     <section
       className="SimpleCard__Image-sc-1rn6x81-1 ixHnGb"
@@ -1805,7 +1805,7 @@ exports[`Storyshots organisms/CampaignList Default 1`] = `
     </section>
   </article>
   <article
-    className="SimpleCard__CardWrapper-sc-1rn6x81-0 jPxKjc"
+    className="SimpleCard__CardWrapper-sc-1rn6x81-0 eXcGaU"
   >
     <section
       className="SimpleCard__Image-sc-1rn6x81-1 ixHnGb"

--- a/src/__test__/__snapshots__/storyshop.test.ts.snap
+++ b/src/__test__/__snapshots__/storyshop.test.ts.snap
@@ -1328,6 +1328,565 @@ exports[`Storyshots molecules/WideCard Default 1`] = `
 </article>
 `;
 
+exports[`Storyshots organisms/CampaignList Default 1`] = `
+<div
+  className="CampaignList__CardList-sc-18q27e9-0 fkfzHV"
+>
+  <article
+    className="SimpleCard__CardWrapper-sc-1rn6x81-0 jPxKjc"
+  >
+    <section
+      className="SimpleCard__Image-sc-1rn6x81-1 ixHnGb"
+    >
+      <span
+        style={
+          Object {
+            "background": "none",
+            "border": 0,
+            "bottom": 0,
+            "boxSizing": "border-box",
+            "display": "block",
+            "height": "initial",
+            "left": 0,
+            "margin": 0,
+            "opacity": 1,
+            "overflow": "hidden",
+            "padding": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+            "width": "initial",
+          }
+        }
+      >
+        <img
+          data-nimg="fill"
+          decoding="async"
+          src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
+          style={
+            Object {
+              "border": "none",
+              "bottom": 0,
+              "boxSizing": "border-box",
+              "display": "block",
+              "height": 0,
+              "left": 0,
+              "margin": "auto",
+              "maxHeight": "100%",
+              "maxWidth": "100%",
+              "minHeight": "100%",
+              "minWidth": "100%",
+              "objectFit": undefined,
+              "objectPosition": undefined,
+              "padding": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+              "width": 0,
+            }
+          }
+        />
+        <noscript>
+          <img
+            data-nimg="fill"
+            decoding="async"
+            loading="lazy"
+            src="https://picsum.photos/id/100/300/200"
+            style={
+              Object {
+                "border": "none",
+                "bottom": 0,
+                "boxSizing": "border-box",
+                "display": "block",
+                "height": 0,
+                "left": 0,
+                "margin": "auto",
+                "maxHeight": "100%",
+                "maxWidth": "100%",
+                "minHeight": "100%",
+                "minWidth": "100%",
+                "objectFit": undefined,
+                "objectPosition": undefined,
+                "padding": 0,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+                "width": 0,
+              }
+            }
+          />
+        </noscript>
+      </span>
+    </section>
+    <section
+      className="SimpleCard__Content-sc-1rn6x81-2 lebyxT"
+    >
+      文房具セール
+    </section>
+  </article>
+  <article
+    className="SimpleCard__CardWrapper-sc-1rn6x81-0 jPxKjc"
+  >
+    <section
+      className="SimpleCard__Image-sc-1rn6x81-1 ixHnGb"
+    >
+      <span
+        style={
+          Object {
+            "background": "none",
+            "border": 0,
+            "bottom": 0,
+            "boxSizing": "border-box",
+            "display": "block",
+            "height": "initial",
+            "left": 0,
+            "margin": 0,
+            "opacity": 1,
+            "overflow": "hidden",
+            "padding": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+            "width": "initial",
+          }
+        }
+      >
+        <img
+          data-nimg="fill"
+          decoding="async"
+          src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
+          style={
+            Object {
+              "border": "none",
+              "bottom": 0,
+              "boxSizing": "border-box",
+              "display": "block",
+              "height": 0,
+              "left": 0,
+              "margin": "auto",
+              "maxHeight": "100%",
+              "maxWidth": "100%",
+              "minHeight": "100%",
+              "minWidth": "100%",
+              "objectFit": undefined,
+              "objectPosition": undefined,
+              "padding": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+              "width": 0,
+            }
+          }
+        />
+        <noscript>
+          <img
+            data-nimg="fill"
+            decoding="async"
+            loading="lazy"
+            src="https://picsum.photos/id/200/300/200"
+            style={
+              Object {
+                "border": "none",
+                "bottom": 0,
+                "boxSizing": "border-box",
+                "display": "block",
+                "height": 0,
+                "left": 0,
+                "margin": "auto",
+                "maxHeight": "100%",
+                "maxWidth": "100%",
+                "minHeight": "100%",
+                "minWidth": "100%",
+                "objectFit": undefined,
+                "objectPosition": undefined,
+                "padding": 0,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+                "width": 0,
+              }
+            }
+          />
+        </noscript>
+      </span>
+    </section>
+    <section
+      className="SimpleCard__Content-sc-1rn6x81-2 lebyxT"
+    >
+      キャンプ用品セール
+    </section>
+  </article>
+  <article
+    className="SimpleCard__CardWrapper-sc-1rn6x81-0 jPxKjc"
+  >
+    <section
+      className="SimpleCard__Image-sc-1rn6x81-1 ixHnGb"
+    >
+      <span
+        style={
+          Object {
+            "background": "none",
+            "border": 0,
+            "bottom": 0,
+            "boxSizing": "border-box",
+            "display": "block",
+            "height": "initial",
+            "left": 0,
+            "margin": 0,
+            "opacity": 1,
+            "overflow": "hidden",
+            "padding": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+            "width": "initial",
+          }
+        }
+      >
+        <img
+          data-nimg="fill"
+          decoding="async"
+          src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
+          style={
+            Object {
+              "border": "none",
+              "bottom": 0,
+              "boxSizing": "border-box",
+              "display": "block",
+              "height": 0,
+              "left": 0,
+              "margin": "auto",
+              "maxHeight": "100%",
+              "maxWidth": "100%",
+              "minHeight": "100%",
+              "minWidth": "100%",
+              "objectFit": undefined,
+              "objectPosition": undefined,
+              "padding": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+              "width": 0,
+            }
+          }
+        />
+        <noscript>
+          <img
+            data-nimg="fill"
+            decoding="async"
+            loading="lazy"
+            src="https://picsum.photos/id/300/300/200"
+            style={
+              Object {
+                "border": "none",
+                "bottom": 0,
+                "boxSizing": "border-box",
+                "display": "block",
+                "height": 0,
+                "left": 0,
+                "margin": "auto",
+                "maxHeight": "100%",
+                "maxWidth": "100%",
+                "minHeight": "100%",
+                "minWidth": "100%",
+                "objectFit": undefined,
+                "objectPosition": undefined,
+                "padding": 0,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+                "width": 0,
+              }
+            }
+          />
+        </noscript>
+      </span>
+    </section>
+    <section
+      className="SimpleCard__Content-sc-1rn6x81-2 lebyxT"
+    >
+      文房具セール
+    </section>
+  </article>
+  <article
+    className="SimpleCard__CardWrapper-sc-1rn6x81-0 jPxKjc"
+  >
+    <section
+      className="SimpleCard__Image-sc-1rn6x81-1 ixHnGb"
+    >
+      <span
+        style={
+          Object {
+            "background": "none",
+            "border": 0,
+            "bottom": 0,
+            "boxSizing": "border-box",
+            "display": "block",
+            "height": "initial",
+            "left": 0,
+            "margin": 0,
+            "opacity": 1,
+            "overflow": "hidden",
+            "padding": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+            "width": "initial",
+          }
+        }
+      >
+        <img
+          data-nimg="fill"
+          decoding="async"
+          src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
+          style={
+            Object {
+              "border": "none",
+              "bottom": 0,
+              "boxSizing": "border-box",
+              "display": "block",
+              "height": 0,
+              "left": 0,
+              "margin": "auto",
+              "maxHeight": "100%",
+              "maxWidth": "100%",
+              "minHeight": "100%",
+              "minWidth": "100%",
+              "objectFit": undefined,
+              "objectPosition": undefined,
+              "padding": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+              "width": 0,
+            }
+          }
+        />
+        <noscript>
+          <img
+            data-nimg="fill"
+            decoding="async"
+            loading="lazy"
+            src="https://picsum.photos/id/400/300/200"
+            style={
+              Object {
+                "border": "none",
+                "bottom": 0,
+                "boxSizing": "border-box",
+                "display": "block",
+                "height": 0,
+                "left": 0,
+                "margin": "auto",
+                "maxHeight": "100%",
+                "maxWidth": "100%",
+                "minHeight": "100%",
+                "minWidth": "100%",
+                "objectFit": undefined,
+                "objectPosition": undefined,
+                "padding": 0,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+                "width": 0,
+              }
+            }
+          />
+        </noscript>
+      </span>
+    </section>
+    <section
+      className="SimpleCard__Content-sc-1rn6x81-2 lebyxT"
+    >
+      キャンプ用品セール
+    </section>
+  </article>
+  <article
+    className="SimpleCard__CardWrapper-sc-1rn6x81-0 jPxKjc"
+  >
+    <section
+      className="SimpleCard__Image-sc-1rn6x81-1 ixHnGb"
+    >
+      <span
+        style={
+          Object {
+            "background": "none",
+            "border": 0,
+            "bottom": 0,
+            "boxSizing": "border-box",
+            "display": "block",
+            "height": "initial",
+            "left": 0,
+            "margin": 0,
+            "opacity": 1,
+            "overflow": "hidden",
+            "padding": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+            "width": "initial",
+          }
+        }
+      >
+        <img
+          data-nimg="fill"
+          decoding="async"
+          src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
+          style={
+            Object {
+              "border": "none",
+              "bottom": 0,
+              "boxSizing": "border-box",
+              "display": "block",
+              "height": 0,
+              "left": 0,
+              "margin": "auto",
+              "maxHeight": "100%",
+              "maxWidth": "100%",
+              "minHeight": "100%",
+              "minWidth": "100%",
+              "objectFit": undefined,
+              "objectPosition": undefined,
+              "padding": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+              "width": 0,
+            }
+          }
+        />
+        <noscript>
+          <img
+            data-nimg="fill"
+            decoding="async"
+            loading="lazy"
+            src="https://picsum.photos/id/300/300/200"
+            style={
+              Object {
+                "border": "none",
+                "bottom": 0,
+                "boxSizing": "border-box",
+                "display": "block",
+                "height": 0,
+                "left": 0,
+                "margin": "auto",
+                "maxHeight": "100%",
+                "maxWidth": "100%",
+                "minHeight": "100%",
+                "minWidth": "100%",
+                "objectFit": undefined,
+                "objectPosition": undefined,
+                "padding": 0,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+                "width": 0,
+              }
+            }
+          />
+        </noscript>
+      </span>
+    </section>
+    <section
+      className="SimpleCard__Content-sc-1rn6x81-2 lebyxT"
+    >
+      文房具セール
+    </section>
+  </article>
+  <article
+    className="SimpleCard__CardWrapper-sc-1rn6x81-0 jPxKjc"
+  >
+    <section
+      className="SimpleCard__Image-sc-1rn6x81-1 ixHnGb"
+    >
+      <span
+        style={
+          Object {
+            "background": "none",
+            "border": 0,
+            "bottom": 0,
+            "boxSizing": "border-box",
+            "display": "block",
+            "height": "initial",
+            "left": 0,
+            "margin": 0,
+            "opacity": 1,
+            "overflow": "hidden",
+            "padding": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+            "width": "initial",
+          }
+        }
+      >
+        <img
+          data-nimg="fill"
+          decoding="async"
+          src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
+          style={
+            Object {
+              "border": "none",
+              "bottom": 0,
+              "boxSizing": "border-box",
+              "display": "block",
+              "height": 0,
+              "left": 0,
+              "margin": "auto",
+              "maxHeight": "100%",
+              "maxWidth": "100%",
+              "minHeight": "100%",
+              "minWidth": "100%",
+              "objectFit": undefined,
+              "objectPosition": undefined,
+              "padding": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+              "width": 0,
+            }
+          }
+        />
+        <noscript>
+          <img
+            data-nimg="fill"
+            decoding="async"
+            loading="lazy"
+            src="https://picsum.photos/id/400/300/200"
+            style={
+              Object {
+                "border": "none",
+                "bottom": 0,
+                "boxSizing": "border-box",
+                "display": "block",
+                "height": 0,
+                "left": 0,
+                "margin": "auto",
+                "maxHeight": "100%",
+                "maxWidth": "100%",
+                "minHeight": "100%",
+                "minWidth": "100%",
+                "objectFit": undefined,
+                "objectPosition": undefined,
+                "padding": 0,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+                "width": 0,
+              }
+            }
+          />
+        </noscript>
+      </span>
+    </section>
+    <section
+      className="SimpleCard__Content-sc-1rn6x81-2 lebyxT"
+    >
+      キャンプ用品セール
+    </section>
+  </article>
+</div>
+`;
+
 exports[`Storyshots organisms/Footer Footer 1`] = `
 <footer
   className="Footer__Wrapper-sc-10gingb-0 jJIwnP"

--- a/src/__test__/__snapshots__/storyshop.test.ts.snap
+++ b/src/__test__/__snapshots__/storyshop.test.ts.snap
@@ -1332,7 +1332,7 @@ exports[`Storyshots molecules/WideCard Default 1`] = `
 
 exports[`Storyshots organisms/CampaignList Default 1`] = `
 <div
-  className="CampaignList__CardList-sc-18q27e9-0 hAwqHH"
+  className="CampaignList__CardList-sc-18q27e9-0 dnsKMR"
 >
   <article
     className="SimpleCard__CardWrapper-sc-1rn6x81-0 eXcGaU"

--- a/src/components/atoms/SimpleCard/index.tsx
+++ b/src/components/atoms/SimpleCard/index.tsx
@@ -5,16 +5,17 @@ import { fontSizes, roundings, shadows, spacingSizes } from 'src/styles/Tokens';
 import { breakpoint } from 'src/styles/breakpoint';
 
 const CardWrapper = styled.article`
+  box-shadow: ${shadows.md};
+  border-radius: ${roundings.md};
+
   ${breakpoint.mb(css`
+    width: 200px;
     font-size: ${fontSizes.fontSize12};
   `)}
   ${breakpoint.pc(css`
+    width: 244px;
     font-size: ${fontSizes.fontSize18};
   `)}
-
-  box-shadow: ${shadows.md};
-  width: fit-content;
-  border-radius: ${roundings.md};
 `;
 
 const Image = styled.section`

--- a/src/components/atoms/SimpleCard/index.tsx
+++ b/src/components/atoms/SimpleCard/index.tsx
@@ -39,6 +39,10 @@ const Content = styled.section`
   `)}
 `;
 
+const RoundedNextImage = styled(NextImage)`
+  border-radius: ${roundings.md} ${roundings.md} 0 0;
+`;
+
 export type SimpleCardProps = {
   children: ReactNode;
   imageUrl: string;
@@ -50,7 +54,7 @@ export const SimpleCard = ({
 }: SimpleCardProps): JSX.Element => (
   <CardWrapper>
     <Image>
-      <NextImage src={imageUrl} layout="fill" />
+      <RoundedNextImage src={imageUrl} layout="fill" />
     </Image>
     <Content>{children}</Content>
   </CardWrapper>

--- a/src/components/organisms/CampaignList/index.stories.tsx
+++ b/src/components/organisms/CampaignList/index.stories.tsx
@@ -1,0 +1,31 @@
+import { ComponentMeta, ComponentStoryObj } from '@storybook/react';
+import { MockAPIProvider } from 'src/storybook/decorators/MockAPIProvider';
+import { CampaignList } from '.';
+
+export default {
+  component: CampaignList,
+  title: 'organisms/CampaignList',
+} as ComponentMeta<typeof CampaignList>;
+
+const response = [
+  {
+    id: '57c3ff77-d8bd-41bb-86e3-4526e1b2186c',
+    name: '文房具セール',
+    thumbnail: 'https://picsum.photos/300/200',
+  },
+  {
+    id: '57c3ff77-d8bd-41bb-86e3-4526e1b2186d',
+    name: 'キャンプ用品セール',
+    thumbnail: 'https://picsum.photos/300/200',
+  },
+];
+
+export const Default: ComponentStoryObj<typeof CampaignList> = {
+  decorators: [
+    (Story) => (
+      <MockAPIProvider response={response}>
+        <Story />
+      </MockAPIProvider>
+    ),
+  ],
+};

--- a/src/components/organisms/CampaignList/index.stories.tsx
+++ b/src/components/organisms/CampaignList/index.stories.tsx
@@ -11,12 +11,12 @@ const response = [
   {
     id: '57c3ff77-d8bd-41bb-86e3-4526e1b2186c',
     name: '文房具セール',
-    thumbnail: 'https://picsum.photos/300/200',
+    thumbnail: 'https://picsum.photos/id/100/300/200',
   },
   {
     id: '57c3ff77-d8bd-41bb-86e3-4526e1b2186d',
     name: 'キャンプ用品セール',
-    thumbnail: 'https://picsum.photos/300/200',
+    thumbnail: 'https://picsum.photos/id/200/300/200',
   },
 ];
 

--- a/src/components/organisms/CampaignList/index.stories.tsx
+++ b/src/components/organisms/CampaignList/index.stories.tsx
@@ -18,6 +18,26 @@ const response = [
     name: 'キャンプ用品セール',
     thumbnail: 'https://picsum.photos/id/200/300/200',
   },
+  {
+    id: '57c3ff77-d8bd-41bb-86e3-4526e1b2186e',
+    name: '文房具セール',
+    thumbnail: 'https://picsum.photos/id/300/300/200',
+  },
+  {
+    id: '57c3ff77-d8bd-41bb-86e3-4526e1b2186f',
+    name: 'キャンプ用品セール',
+    thumbnail: 'https://picsum.photos/id/400/300/200',
+  },
+  {
+    id: '57c3ff77-d8bd-41bb-86e3-4526e1b21870',
+    name: '文房具セール',
+    thumbnail: 'https://picsum.photos/id/300/300/200',
+  },
+  {
+    id: '57c3ff77-d8bd-41bb-86e3-4526e1b21871',
+    name: 'キャンプ用品セール',
+    thumbnail: 'https://picsum.photos/id/400/300/200',
+  },
 ];
 
 export const Default: ComponentStoryObj<typeof CampaignList> = {

--- a/src/components/organisms/CampaignList/index.tsx
+++ b/src/components/organisms/CampaignList/index.tsx
@@ -1,0 +1,7 @@
+import useSWR from 'swr';
+
+export const CampaignList = () => {
+  const { data } = useSWR('/campaigns');
+
+  return <div>{JSON.stringify(data)}</div>;
+};

--- a/src/components/organisms/CampaignList/index.tsx
+++ b/src/components/organisms/CampaignList/index.tsx
@@ -14,14 +14,14 @@ const CardList = styled.div`
   display: flex;
   padding: ${spacingSizes.xs};
 
-  ${breakpoint.pc(css`
-    gap: ${spacingSizes.sm};
-    flex-wrap: wrap;
-  `)};
   ${breakpoint.mb(css`
     gap: ${spacingSizes.xs};
     flex-wrap: nowrap;
     overflow-x: scroll;
+  `)};
+  ${breakpoint.pc(css`
+    gap: ${spacingSizes.sm};
+    flex-wrap: wrap;
   `)};
 `;
 

--- a/src/components/organisms/CampaignList/index.tsx
+++ b/src/components/organisms/CampaignList/index.tsx
@@ -13,11 +13,11 @@ type CampaignsResponse = {
 const CardList = styled.div`
   display: flex;
   padding: ${spacingSizes.xs};
+  width: 100%;
 
   ${breakpoint.mb(css`
     gap: ${spacingSizes.xs};
     flex-wrap: nowrap;
-    overflow-x: scroll;
   `)};
   ${breakpoint.pc(css`
     gap: ${spacingSizes.sm};

--- a/src/components/organisms/CampaignList/index.tsx
+++ b/src/components/organisms/CampaignList/index.tsx
@@ -12,6 +12,7 @@ type CampaignsResponse = {
 
 const CardList = styled.div`
   display: flex;
+  padding: ${spacingSizes.xs};
 
   ${breakpoint.pc(css`
     gap: ${spacingSizes.sm};
@@ -20,6 +21,7 @@ const CardList = styled.div`
   ${breakpoint.mb(css`
     gap: ${spacingSizes.xs};
     flex-wrap: nowrap;
+    overflow-x: scroll;
   `)};
 `;
 

--- a/src/components/organisms/CampaignList/index.tsx
+++ b/src/components/organisms/CampaignList/index.tsx
@@ -1,4 +1,7 @@
 import { SimpleCard } from 'src/components/atoms/SimpleCard';
+import { breakpoint } from 'src/styles/breakpoint';
+import { spacingSizes } from 'src/styles/Tokens';
+import styled, { css } from 'styled-components';
 import useSWR from 'swr';
 
 type CampaignsResponse = {
@@ -7,6 +10,19 @@ type CampaignsResponse = {
   thumbnail: string;
 };
 
+const CardList = styled.div`
+  display: flex;
+
+  ${breakpoint.pc(css`
+    gap: ${spacingSizes.sm};
+    flex-wrap: wrap;
+  `)};
+  ${breakpoint.mb(css`
+    gap: ${spacingSizes.xs};
+    flex-wrap: nowrap;
+  `)};
+`;
+
 export const CampaignList = () => {
   const { data: campaigns } = useSWR<CampaignsResponse[]>('/campaigns');
 
@@ -14,9 +30,13 @@ export const CampaignList = () => {
     return <p>Loading...</p>;
   }
 
-  return campaigns.map((campaign) => (
-    <SimpleCard key={campaign.id} imageUrl={campaign.thumbnail}>
-      {campaign.name}
-    </SimpleCard>
-  ));
+  return (
+    <CardList>
+      {campaigns.map((campaign) => (
+        <SimpleCard key={campaign.id} imageUrl={campaign.thumbnail}>
+          {campaign.name}
+        </SimpleCard>
+      ))}
+    </CardList>
+  );
 };

--- a/src/components/organisms/CampaignList/index.tsx
+++ b/src/components/organisms/CampaignList/index.tsx
@@ -1,7 +1,22 @@
+import { SimpleCard } from 'src/components/atoms/SimpleCard';
 import useSWR from 'swr';
 
-export const CampaignList = () => {
-  const { data } = useSWR('/campaigns');
+type CampaignsResponse = {
+  id: string;
+  name: string;
+  thumbnail: string;
+};
 
-  return <div>{JSON.stringify(data)}</div>;
+export const CampaignList = () => {
+  const { data: campaigns } = useSWR<CampaignsResponse[]>('/campaigns');
+
+  if (campaigns === undefined) {
+    return <p>Loading...</p>;
+  }
+
+  return campaigns.map((campaign) => (
+    <SimpleCard key={campaign.id} imageUrl={campaign.thumbnail}>
+      {campaign.name}
+    </SimpleCard>
+  ));
 };

--- a/src/storybook/decorators/MockAPIProvider.tsx
+++ b/src/storybook/decorators/MockAPIProvider.tsx
@@ -11,7 +11,7 @@ const createMockMiddleWare =
   () =>
   (): SWRResponse => ({
     data: response,
-    mutate: (_) => Promise.resolve<T>(response),
+    mutate: () => Promise.resolve<T>(response),
     isValidating: false,
   });
 

--- a/src/storybook/decorators/MockAPIProvider.tsx
+++ b/src/storybook/decorators/MockAPIProvider.tsx
@@ -1,0 +1,28 @@
+import { ReactNode, useMemo } from 'react';
+import { Middleware, SWRConfig, SWRResponse } from 'swr';
+
+export type MockAPIProviderProps<T> = {
+  children: ReactNode;
+  response: T;
+};
+
+const createMockMiddleWare =
+  <T,>(response: T): Middleware =>
+  () =>
+  (): SWRResponse => ({
+    data: response,
+    mutate: (_) => Promise.resolve<T>(response),
+    isValidating: false,
+  });
+
+export const MockAPIProvider = <T,>({
+  children,
+  response,
+}: MockAPIProviderProps<T>): JSX.Element => {
+  const mockMiddleware = useMemo(
+    () => createMockMiddleWare(response),
+    [response],
+  );
+
+  return <SWRConfig value={{ use: [mockMiddleware] }}>{children}</SWRConfig>;
+};

--- a/src/storybook/decorators/MockAPIProvider.tsx
+++ b/src/storybook/decorators/MockAPIProvider.tsx
@@ -1,9 +1,9 @@
 import { ReactNode, useMemo } from 'react';
 import { Middleware, SWRConfig, SWRResponse } from 'swr';
 
-export type MockAPIProviderProps<T> = {
+export type MockAPIProviderProps = {
   children: ReactNode;
-  response: T;
+  response: unknown;
 };
 
 const createMockMiddleWare =
@@ -15,10 +15,10 @@ const createMockMiddleWare =
     isValidating: false,
   });
 
-export const MockAPIProvider = <T,>({
+export const MockAPIProvider = ({
   children,
   response,
-}: MockAPIProviderProps<T>): JSX.Element => {
+}: MockAPIProviderProps): JSX.Element => {
   const mockMiddleware = useMemo(
     () => createMockMiddleWare(response),
     [response],

--- a/src/storybook/decorators/MockAPIProvider.tsx
+++ b/src/storybook/decorators/MockAPIProvider.tsx
@@ -7,11 +7,11 @@ export type MockAPIProviderProps<T> = {
 };
 
 const createMockMiddleWare =
-  <T,>(response: T): Middleware =>
+  (response: unknown): Middleware =>
   () =>
   (): SWRResponse => ({
     data: response,
-    mutate: () => Promise.resolve<T>(response),
+    mutate: () => Promise.resolve(response),
     isValidating: false,
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -12378,6 +12378,11 @@ supports-preserve-symlinks-flag@^1.0.0:
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
+swr@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/swr/-/swr-1.3.0.tgz#c6531866a35b4db37b38b72c45a63171faf9f4e8"
+  integrity sha512-dkghQrOl2ORX9HYrMDtPa7LTVHJjCTeZoB1dqTbnnEDlSvN8JEKpYIYurDfvbQFUUS8Cg8PceFVZNkW0KNNYPw==
+
 symbol-tree@^3.2.4:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"


### PR DESCRIPTION
# 概要
API につながったキャンペーン一覧を作りました。

# 実装方針
- `swr` を採用しました。モックには middleware を使用する方針をとりました。
- 開発の効率の為、　API のモックやスキーマはコンポーネントや Story と密にするようにしました。

# 動作手順

- Storybook のリンク: http://localhost:6006/?path=/story/organisms-campaignlist--default&globals=backgrounds.grid:false

# キャプチャ
<img width="1504" alt="image" src="https://user-images.githubusercontent.com/55672846/187582710-9bceab71-8b76-4e3c-a0c4-3e22b629d2b5.png">


# レビュー観点 (あれば)
