### PR TITLE
feat: implement information list

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -2,6 +2,7 @@
 import { MINIMAL_VIEWPORTS } from '@storybook/addon-viewport';
 import * as NextImage from 'next/image';
 import GlobalStyle from '../src/styles/Globals';
+import '../src/helper/initializeDayjs';
 
 const OriginalNextImage = NextImage.default;
 

--- a/src/__test__/__snapshots__/storyshop.test.ts.snap
+++ b/src/__test__/__snapshots__/storyshop.test.ts.snap
@@ -1978,6 +1978,87 @@ exports[`Storyshots organisms/Header Header 1`] = `
 </header>
 `;
 
+exports[`Storyshots organisms/InformationList Default 1`] = `
+<div
+  className="InformationList__CardList-sc-74g2h2-0 eZrrwD"
+>
+  <article
+    className="WideCard__WideCardWrapper-sc-nrwjyl-0 iVTiwl"
+  >
+    <div
+      className="WideCard__MetaInformationLine-sc-nrwjyl-1 cuvZVz"
+    >
+      <time
+        className="WideCard__Date-sc-nrwjyl-2 bfpOWL"
+        dateTime="2017-07-22"
+      >
+        2017/07/22
+      </time>
+      <ul
+        className="Tags__TagsWrapper-sc-16wimeq-0 dwINUO"
+      >
+        <li
+          className="Tag__TagWrapper-sc-14oc89a-0 eXcEJX"
+          color="red"
+        >
+          重要
+        </li>
+        <li
+          className="Tag__TagWrapper-sc-14oc89a-0 dthzjQ"
+          color="orange"
+        >
+          メンテナンス
+        </li>
+      </ul>
+    </div>
+    <p
+      className="WideCard__Content-sc-nrwjyl-3 kAkQkf"
+    >
+      本日の19:00からメンテナンスのため、一時間ほどのサービス停止を予定しています。
+再開しだいメールにてアナウンスさせていただきます。
+ご迷惑をおかけしますが、ご理解ご協力のほどをよろしくお願いいたします。
+    </p>
+  </article>
+  <article
+    className="WideCard__WideCardWrapper-sc-nrwjyl-0 iVTiwl"
+  >
+    <div
+      className="WideCard__MetaInformationLine-sc-nrwjyl-1 cuvZVz"
+    >
+      <time
+        className="WideCard__Date-sc-nrwjyl-2 bfpOWL"
+        dateTime="2017-07-22"
+      >
+        2017/07/22
+      </time>
+      <ul
+        className="Tags__TagsWrapper-sc-16wimeq-0 dwINUO"
+      >
+        <li
+          className="Tag__TagWrapper-sc-14oc89a-0 eXcEJX"
+          color="red"
+        >
+          重要
+        </li>
+        <li
+          className="Tag__TagWrapper-sc-14oc89a-0 dthzjQ"
+          color="orange"
+        >
+          メンテナンス
+        </li>
+      </ul>
+    </div>
+    <p
+      className="WideCard__Content-sc-nrwjyl-3 kAkQkf"
+    >
+      本日の19:00からメンテナンスのため、一時間ほどのサービス停止を予定しています。
+再開しだいメールにてアナウンスさせていただきます。
+ご迷惑をおかけしますが、ご理解ご協力のほどをよろしくお願いいたします。
+    </p>
+  </article>
+</div>
+`;
+
 exports[`Storyshots organisms/PromotionsCarousel Default 1`] = `
 <div
   className="Carousel__CarouselWrapper-sc-1ey4ea4-0 jSTejE"

--- a/src/__test__/__snapshots__/storyshop.test.ts.snap
+++ b/src/__test__/__snapshots__/storyshop.test.ts.snap
@@ -1254,7 +1254,7 @@ exports[`Storyshots atoms/SimpleCard Default 1`] = `
 
 exports[`Storyshots atoms/Tag Default 1`] = `
 <li
-  className="Tag__TagWrapper-sc-14oc89a-0 hkYttr"
+  className="Tag__TagWrapper-sc-14oc89a-0 jmbcSW"
   color="#ff0000"
 >
   Tag
@@ -1266,19 +1266,19 @@ exports[`Storyshots molecules/Tags Default 1`] = `
   className="Tags__TagsWrapper-sc-16wimeq-0 dwINUO"
 >
   <li
-    className="Tag__TagWrapper-sc-14oc89a-0 hkYttr"
+    className="Tag__TagWrapper-sc-14oc89a-0 jmbcSW"
     color="#ff0000"
   >
     Tag-A
   </li>
   <li
-    className="Tag__TagWrapper-sc-14oc89a-0 fgdIoT"
+    className="Tag__TagWrapper-sc-14oc89a-0 jzdEHK"
     color="green"
   >
     Tag-B
   </li>
   <li
-    className="Tag__TagWrapper-sc-14oc89a-0 jTTwrj"
+    className="Tag__TagWrapper-sc-14oc89a-0 RcNki"
     color="#0000ff"
   >
     Tag-C
@@ -1303,19 +1303,19 @@ exports[`Storyshots molecules/WideCard Default 1`] = `
       className="Tags__TagsWrapper-sc-16wimeq-0 dwINUO"
     >
       <li
-        className="Tag__TagWrapper-sc-14oc89a-0 eXcEJX"
+        className="Tag__TagWrapper-sc-14oc89a-0 jrWDKq"
         color="red"
       >
         Tag-1
       </li>
       <li
-        className="Tag__TagWrapper-sc-14oc89a-0 fgdIoT"
+        className="Tag__TagWrapper-sc-14oc89a-0 jzdEHK"
         color="green"
       >
         Tag-2
       </li>
       <li
-        className="Tag__TagWrapper-sc-14oc89a-0 bYpkuq"
+        className="Tag__TagWrapper-sc-14oc89a-0 irPjbz"
         color="blue"
       >
         Tag-3
@@ -1998,13 +1998,13 @@ exports[`Storyshots organisms/InformationList Default 1`] = `
         className="Tags__TagsWrapper-sc-16wimeq-0 dwINUO"
       >
         <li
-          className="Tag__TagWrapper-sc-14oc89a-0 eXcEJX"
+          className="Tag__TagWrapper-sc-14oc89a-0 jrWDKq"
           color="red"
         >
           重要
         </li>
         <li
-          className="Tag__TagWrapper-sc-14oc89a-0 dthzjQ"
+          className="Tag__TagWrapper-sc-14oc89a-0 gWhrIB"
           color="orange"
         >
           メンテナンス
@@ -2035,13 +2035,13 @@ exports[`Storyshots organisms/InformationList Default 1`] = `
         className="Tags__TagsWrapper-sc-16wimeq-0 dwINUO"
       >
         <li
-          className="Tag__TagWrapper-sc-14oc89a-0 eXcEJX"
+          className="Tag__TagWrapper-sc-14oc89a-0 jrWDKq"
           color="red"
         >
           重要
         </li>
         <li
-          className="Tag__TagWrapper-sc-14oc89a-0 dthzjQ"
+          className="Tag__TagWrapper-sc-14oc89a-0 gWhrIB"
           color="orange"
         >
           メンテナンス

--- a/src/components/atoms/Tag/index.tsx
+++ b/src/components/atoms/Tag/index.tsx
@@ -12,13 +12,14 @@ const TagWrapper = styled.li<Pick<TagProps, 'color'>>`
   background-color: ${(props) => props.color};
   color: white;
   list-style: none;
-  padding: 0 ${spacingSizes.xs};
 
   ${breakpoint.mb(css`
     font-size: 12px;
+    padding: 0 ${spacingSizes.xxs};
   `)}
   ${breakpoint.pc(css`
     font-size: 22px;
+    padding: 0 ${spacingSizes.xs};
   `)}
 `;
 

--- a/src/components/molecules/WideCard/index.tsx
+++ b/src/components/molecules/WideCard/index.tsx
@@ -4,6 +4,8 @@ import { fontSizes, roundings, shadows, spacingSizes } from 'src/styles/Tokens';
 import styled, { css } from 'styled-components';
 import { Tags } from 'src/components/molecules/Tags';
 import dayjs from 'dayjs';
+import 'dayjs/plugin/utc';
+import 'dayjs/plugin/timezone';
 
 const WideCardWrapper = styled.article`
   display: flex;
@@ -67,7 +69,7 @@ export const WideCard = ({
   tags,
   text,
 }: WideCardProps): JSX.Element => {
-  const date = dayjs(rawDate);
+  const date = dayjs(rawDate).tz();
 
   return (
     <WideCardWrapper>

--- a/src/components/organisms/InformationList/index.stories.tsx
+++ b/src/components/organisms/InformationList/index.stories.tsx
@@ -1,0 +1,57 @@
+import { ComponentMeta, ComponentStoryObj } from '@storybook/react';
+import { mockAPIDecorator } from 'src/storybook/decorators/MockAPIProvider';
+import { InformationList } from '.';
+
+export default {
+  component: InformationList,
+  title: 'organisms/InformationList',
+} as ComponentMeta<typeof InformationList>;
+
+const response = [
+  {
+    id: '57c3ff77-d8bd-41bb-86e3-4526e1b2186c',
+    title: 'メンテナンスのお知らせ',
+    detail:
+      '本日の19:00からメンテナンスのため、一時間ほどのサービス停止を予定しています。\n再開しだいメールにてアナウンスさせていただきます。\nご迷惑をおかけしますが、ご理解ご協力のほどをよろしくお願いいたします。',
+    tags: [
+      {
+        id: '57c3ff77-d8bd-41bb-86e3-4526e1b2186c',
+        name: '重要',
+        color: 'red',
+        tag_group: 'information',
+      },
+      {
+        id: '57c3ff77-d8bd-41bb-86e3-4526e1b2186d',
+        name: 'メンテナンス',
+        color: 'orange',
+        tag_group: 'information',
+      },
+    ],
+    announced_at: '2017-07-21T17:32:28Z',
+  },
+  {
+    id: '57c3ff77-d8bd-41bb-86e3-4526e1b2186c',
+    title: 'メンテナンスのお知らせ',
+    detail:
+      '本日の19:00からメンテナンスのため、一時間ほどのサービス停止を予定しています。\n再開しだいメールにてアナウンスさせていただきます。\nご迷惑をおかけしますが、ご理解ご協力のほどをよろしくお願いいたします。',
+    tags: [
+      {
+        id: '57c3ff77-d8bd-41bb-86e3-4526e1b2186c',
+        name: '重要',
+        color: 'red',
+        tag_group: 'information',
+      },
+      {
+        id: '57c3ff77-d8bd-41bb-86e3-4526e1b2186d',
+        name: 'メンテナンス',
+        color: 'orange',
+        tag_group: 'information',
+      },
+    ],
+    announced_at: '2017-07-21T17:32:28Z',
+  },
+];
+
+export const Default: ComponentStoryObj<typeof InformationList> = {
+  decorators: [mockAPIDecorator(response)],
+};

--- a/src/components/organisms/InformationList/index.stories.tsx
+++ b/src/components/organisms/InformationList/index.stories.tsx
@@ -15,13 +15,13 @@ const response = [
       '本日の19:00からメンテナンスのため、一時間ほどのサービス停止を予定しています。\n再開しだいメールにてアナウンスさせていただきます。\nご迷惑をおかけしますが、ご理解ご協力のほどをよろしくお願いいたします。',
     tags: [
       {
-        id: '57c3ff77-d8bd-41bb-86e3-4526e1b2186c',
+        id: '57c3ff77-d8bd-41bb-86e3-4526e1b2186d',
         name: '重要',
         color: 'red',
         tag_group: 'information',
       },
       {
-        id: '57c3ff77-d8bd-41bb-86e3-4526e1b2186d',
+        id: '57c3ff77-d8bd-41bb-86e3-4526e1b2186e',
         name: 'メンテナンス',
         color: 'orange',
         tag_group: 'information',
@@ -30,19 +30,19 @@ const response = [
     announced_at: '2017-07-21T17:32:28Z',
   },
   {
-    id: '57c3ff77-d8bd-41bb-86e3-4526e1b2186c',
+    id: '57c3ff77-d8bd-41bb-86e3-4526e1b2186f',
     title: 'メンテナンスのお知らせ',
     detail:
       '本日の19:00からメンテナンスのため、一時間ほどのサービス停止を予定しています。\n再開しだいメールにてアナウンスさせていただきます。\nご迷惑をおかけしますが、ご理解ご協力のほどをよろしくお願いいたします。',
     tags: [
       {
-        id: '57c3ff77-d8bd-41bb-86e3-4526e1b2186c',
+        id: '57c3ff77-d8bd-41bb-86e3-4526e1b21870',
         name: '重要',
         color: 'red',
         tag_group: 'information',
       },
       {
-        id: '57c3ff77-d8bd-41bb-86e3-4526e1b2186d',
+        id: '57c3ff77-d8bd-41bb-86e3-4526e1b21871',
         name: 'メンテナンス',
         color: 'orange',
         tag_group: 'information',

--- a/src/components/organisms/InformationList/index.tsx
+++ b/src/components/organisms/InformationList/index.tsx
@@ -1,0 +1,65 @@
+import { useMemo } from 'react';
+import { TagProps } from 'src/components/atoms/Tag';
+import { WideCard, WideCardProps } from 'src/components/molecules/WideCard';
+import { breakpoint } from 'src/styles/breakpoint';
+import { spacingSizes } from 'src/styles/Tokens';
+import styled, { css } from 'styled-components';
+import useSWR from 'swr';
+
+type TagResponse = {
+  id: string;
+  name: string;
+  color: string;
+  tag_group: string;
+};
+
+type InformationResponse = {
+  id: string;
+  title: string;
+  detail: string;
+  tags: TagResponse[];
+  announced_at: string;
+};
+
+const generateTagProps = (tag: TagResponse): TagProps => ({
+  name: tag.name,
+  color: tag.color,
+});
+
+const generateWideCardProps = (info: InformationResponse): WideCardProps => ({
+  date: info.announced_at,
+  text: info.detail,
+  tags: info.tags.map(generateTagProps),
+});
+
+const CardList = styled.div`
+  display: flex;
+  flex-direction: column;
+
+  ${breakpoint.mb(css`
+    gap: ${spacingSizes.xs};
+  `)};
+  ${breakpoint.pc(css`
+    gap: ${spacingSizes.sm};
+  `)};
+`;
+
+export const InformationList = (): JSX.Element => {
+  const { data: information } = useSWR<InformationResponse[]>('/informations');
+  const cardProps: WideCardProps[] | undefined = useMemo(
+    () => information?.map(generateWideCardProps),
+    [information],
+  );
+
+  if (cardProps === undefined) {
+    return <p>Loading...</p>;
+  }
+
+  return (
+    <CardList>
+      {cardProps.map((prop) => (
+        <WideCard {...prop} />
+      ))}
+    </CardList>
+  );
+};

--- a/src/components/organisms/InformationList/index.tsx
+++ b/src/components/organisms/InformationList/index.tsx
@@ -26,12 +26,6 @@ const generateTagProps = (tag: TagResponse): TagProps => ({
   color: tag.color,
 });
 
-const generateWideCardProps = (info: InformationResponse): WideCardProps => ({
-  date: info.announced_at,
-  text: info.detail,
-  tags: info.tags.map(generateTagProps),
-});
-
 const CardList = styled.div`
   display: flex;
   flex-direction: column;
@@ -46,19 +40,20 @@ const CardList = styled.div`
 
 export const InformationList = (): JSX.Element => {
   const { data: information } = useSWR<InformationResponse[]>('/informations');
-  const cardProps: WideCardProps[] | undefined = useMemo(
-    () => information?.map(generateWideCardProps),
-    [information],
-  );
 
-  if (cardProps === undefined) {
+  if (information === undefined) {
     return <p>Loading...</p>;
   }
 
   return (
     <CardList>
-      {cardProps.map((prop) => (
-        <WideCard {...prop} />
+      {information.map((info) => (
+        <WideCard
+          key={info.id}
+          date={info.announced_at}
+          text={info.detail}
+          tags={info.tags.map(generateTagProps)}
+        />
       ))}
     </CardList>
   );

--- a/src/components/organisms/InformationList/index.tsx
+++ b/src/components/organisms/InformationList/index.tsx
@@ -1,6 +1,5 @@
-import { useMemo } from 'react';
 import { TagProps } from 'src/components/atoms/Tag';
-import { WideCard, WideCardProps } from 'src/components/molecules/WideCard';
+import { WideCard } from 'src/components/molecules/WideCard';
 import { breakpoint } from 'src/styles/breakpoint';
 import { spacingSizes } from 'src/styles/Tokens';
 import styled, { css } from 'styled-components';

--- a/src/helper/initializeDayjs.ts
+++ b/src/helper/initializeDayjs.ts
@@ -1,0 +1,8 @@
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+import timezone from 'dayjs/plugin/timezone';
+
+dayjs.extend(timezone);
+dayjs.extend(utc);
+
+dayjs.tz.setDefault('Asia/Tokyo');

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,5 +1,6 @@
 import type { AppProps } from 'next/app';
 import GlobalStyle from 'src/styles/Globals';
+import 'helper/initializeDayjs';
 
 function MyApp({ Component, pageProps }: AppProps) {
   return (

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,6 +1,6 @@
 import type { AppProps } from 'next/app';
 import GlobalStyle from 'src/styles/Globals';
-import 'helper/initializeDayjs';
+import 'src/helper/initializeDayjs';
 
 function MyApp({ Component, pageProps }: AppProps) {
   return (


### PR DESCRIPTION
# 概要
お知らせ一覧を実装しました。

# 実装方針
- API のレスポンスから props を生成するときの処理が他の物に比べて複雑になりそうだったため、関数に切り出す形にしました。

# 動作手順

- Storybook のリンク: http://localhost:6006/?path=/story/organisms-informationlist--default&globals=backgrounds.grid:true

# キャプチャ
<img width="1076" alt="image" src="https://user-images.githubusercontent.com/55672846/187612341-63cccd2d-2812-433f-a92c-99959065b8cb.png">

# レビュー観点 (あれば)
